### PR TITLE
Add X11/i3 Support via Pluggable Backend Architecture

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,38 @@
+package main
+
+import "context"
+
+// Backend handles window manager specific operations
+type Backend interface {
+	// GetWindowClass returns the class/app ID of the focused window
+	GetWindowClass(ctx context.Context) (string, error)
+
+	// TypeText types the given text into the focused window
+	TypeText(text string) error
+
+	// PasteText copies text to clipboard and pastes it
+	PasteText(text string) error
+}
+
+// ShouldPaste determines if we should paste (for firefox) or type directly
+func ShouldPaste(windowClass string) bool {
+	// Check if window class contains "firefox" (case insensitive)
+	for _, char := range windowClass {
+		if char >= 'A' && char <= 'Z' {
+			windowClass = string(append([]byte{}, byte(char+32)))
+		}
+	}
+	return containsSubstring(windowClass, "firefox")
+}
+
+func containsSubstring(s, substr string) bool {
+	if len(substr) > len(s) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/backend_sway.go
+++ b/backend_sway.go
@@ -1,0 +1,60 @@
+//go:build !x11
+
+package main
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/joshuarubin/go-sway"
+	"github.com/pkg/errors"
+)
+
+// SwayBackend implements Backend for Sway/Wayland
+type SwayBackend struct {
+	client sway.Client
+}
+
+// NewBackend creates a new Sway backend
+func NewBackend(ctx context.Context) (Backend, error) {
+	client, err := sway.New(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &SwayBackend{client: client}, nil
+}
+
+// GetWindowClass returns the app ID of the focused window
+func (b *SwayBackend) GetWindowClass(ctx context.Context) (string, error) {
+	tree, err := b.client.GetTree(ctx)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	appID := tree.FocusedNode().AppID
+	if appID == nil {
+		return "", nil
+	}
+	return *appID, nil
+}
+
+// TypeText types text using ydotool
+func (b *SwayBackend) TypeText(text string) error {
+	if err := exec.Command("ydotool", "type", "-d=8", "-H=6", text).Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// PasteText copies to clipboard and pastes using ydotool
+func (b *SwayBackend) PasteText(text string) error {
+	wlCopyCmd := exec.Command("wl-copy", "--foreground", text)
+	if err := wlCopyCmd.Start(); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := exec.Command("ydotool", "key", "29:1", "47:1", "47:0", "29:0").Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	wlCopyCmd.Process.Kill()
+	wlCopyCmd.Wait()
+	return nil
+}

--- a/backend_x11.go
+++ b/backend_x11.go
@@ -1,0 +1,50 @@
+//go:build x11
+
+package main
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// X11Backend implements Backend for X11/i3
+type X11Backend struct{}
+
+// NewBackend creates a new X11 backend
+func NewBackend(ctx context.Context) (Backend, error) {
+	return &X11Backend{}, nil
+}
+
+// GetWindowClass returns the window class of the focused window
+func (b *X11Backend) GetWindowClass(ctx context.Context) (string, error) {
+	cmd := exec.Command("xdotool", "getwindowfocus", "getwindowclassname")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// TypeText types text using xdotool
+func (b *X11Backend) TypeText(text string) error {
+	if err := exec.Command("xdotool", "type", "--delay", "8", text).Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// PasteText copies to clipboard and pastes using xdotool
+func (b *X11Backend) PasteText(text string) error {
+	xclipCmd := exec.Command("xclip", "-selection", "clipboard")
+	xclipCmd.Stdin = strings.NewReader(text)
+	if err := xclipCmd.Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := exec.Command("xdotool", "key", "ctrl+v").Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,133 @@
 # whispy
 
 A daemon process that works using
-[`pw-record`](https://docs.pipewire.org/page_man_pw-cat_1.html),
-[`ydotool`](https://github.com/ReimuNotMoe/ydotool) and of course
+[`pw-record`](https://docs.pipewire.org/page_man_pw-cat_1.html) and
 [`whisper.cpp`](https://github.com/ggml-org/whisper.cpp) to provide
-speech-to-text/dictation for Linux/Wayland.
+speech-to-text/dictation for Linux.
 
-Grab a model from [huggingface](https://huggingface.co/ggerganov/whisper.cpp).
+Supports both **Wayland/Sway** and **X11/i3** window managers.
 
-## Sway Setup
+## Prerequisites
 
-Once you've built and installed the binary and a model, add something like this to your config:
+### Common Requirements
+- `pw-record` (from PipeWire) - for audio recording
+- A whisper.cpp model from [huggingface](https://huggingface.co/ggerganov/whisper.cpp)
+
+### For Sway/Wayland (default)
+- [`ydotool`](https://github.com/ReimuNotMoe/ydotool) - for typing and keyboard control
+- `wl-clipboard` (provides `wl-copy`) - for clipboard operations
+
+### For i3/X11
+- `xdotool` - for typing and keyboard control
+- `xclip` - for clipboard operations
+
+## Building
+
+### For Sway/Wayland (default)
+```bash
+./build-whisper  # Build whisper.cpp library first
+go build
+```
+
+### For i3/X11
+```bash
+./build-whisper  # Build whisper.cpp library first
+go build -tags=x11
+```
+
+## Setup
+
+### Sway Setup
+
+Once you've built the binary and downloaded a model, add this to your Sway config:
 
 ```
-exec whispy /home/naitik/.cache/whisper/ggml-large-v3-turbo-q5_0.bin
+exec whispy /home/user/.cache/whisper/ggml-base.en.bin
 bindsym $mod+grave exec 'pkill -USR2 whispy'
 ```
 
-That sets up mod+grave as your toggle.
+### i3 Setup
+
+For i3, you'll want to use the included `start-whispy.sh` script for proper daemonization:
+
+```
+# i3 config (~/.config/i3/config)
+exec --no-startup-id /path/to/whispy/start-whispy.sh
+bindsym $mod+grave exec --no-startup-id pkill -USR2 whispy
+```
+
+The `start-whispy.sh` script (included in `scripts/`) ensures whispy runs as a proper daemon.
+
+## Usage
+
+Press `$mod+grave` (typically Super/Windows + backtick) to:
+1. **Start recording** - Press once to begin recording audio
+2. **Stop and transcribe** - Press again to stop recording and transcribe
+
+The transcribed text will be:
+- **Typed directly** into most applications
+- **Pasted** (via clipboard) into Firefox (for better compatibility)
+
+## Status Monitoring
+
+### Command Line
+Use the included `scripts/whispy-status.sh` to check if whispy is recording:
+
+```bash
+./scripts/whispy-status.sh
+```
+
+Shows:
+- `⚪ Idle` - Not recording
+- `🔴 RECORDING` - Currently recording (with audio file size)
+- `⚠️ whispy is NOT running` - Daemon not active
+
+### i3bar Integration
+For visual feedback in your i3 status bar, use the included bumblebee-status module:
+
+1. Copy `scripts/bumblebee-status/whispy.py` to `~/.config/bumblebee-status/modules/`
+2. Add `whispy` to your i3bar status_command:
+
+```
+bar {
+    status_command bumblebee-status -m \
+        whispy memory date time battery \
+        ...
+}
+```
+
+The indicator shows:
+- **⚪** - Idle (not recording)
+- **🔴REC** - Recording active
+
+## Troubleshooting
+
+**Check if whispy is running:**
+```bash
+pgrep whispy
+```
+
+**View logs (if using start-whispy.sh):**
+```bash
+tail -f /tmp/whispy.log
+```
+
+**Test recording manually:**
+```bash
+# Start recording
+pkill -USR2 whispy
+
+# Speak into microphone...
+
+# Stop and transcribe
+pkill -USR2 whispy
+```
+
+**Dependencies check:**
+```bash
+# For Sway/Wayland
+which ydotool wl-copy pw-record
+
+# For i3/X11
+which xdotool xclip pw-record
+```

--- a/scripts/bumblebee-status/whispy.py
+++ b/scripts/bumblebee-status/whispy.py
@@ -1,0 +1,24 @@
+"""Display whispy recording status"""
+
+import core.module
+import core.widget
+import core.decorators
+import subprocess
+
+class Module(core.module.Module):
+    @core.decorators.every(seconds=1)
+    def __init__(self, config, theme):
+        super().__init__(config, theme, core.widget.Widget(self.status))
+
+    def status(self, widget):
+        try:
+            # Check if pw-record is running (means recording is active)
+            result = subprocess.run(['pgrep', '-x', 'pw-record'],
+                                  capture_output=True,
+                                  timeout=1)
+            if result.returncode == 0:
+                return "🔴REC"
+            else:
+                return "⚪"
+        except:
+            return "?"

--- a/scripts/start-whispy.sh
+++ b/scripts/start-whispy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Start whispy daemon with proper backgrounding
+#
+# Usage: start-whispy.sh [path-to-model]
+#
+# If no model path is provided, defaults to ~/.cache/whisper/ggml-base.en.bin
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHISPY_BIN="${SCRIPT_DIR}/../whispy"
+MODEL_PATH="${1:-${HOME}/.cache/whisper/ggml-base.en.bin}"
+LOG_FILE="${WHISPY_LOG:-/tmp/whispy.log}"
+
+if [ ! -f "$WHISPY_BIN" ]; then
+    echo "Error: whispy binary not found at $WHISPY_BIN" >&2
+    exit 1
+fi
+
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "Error: Model file not found at $MODEL_PATH" >&2
+    exit 1
+fi
+
+nohup "$WHISPY_BIN" "$MODEL_PATH" >> "$LOG_FILE" 2>&1 &
+disown

--- a/scripts/whispy-status.sh
+++ b/scripts/whispy-status.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Check whispy daemon and recording status
+
+# Check if whispy is running
+if ! pgrep -x whispy > /dev/null; then
+    echo "⚠️  whispy is NOT running"
+    exit 1
+fi
+
+# Check if recording is active (pw-record process exists)
+if pgrep -x pw-record > /dev/null; then
+    echo "🔴 RECORDING - Press \$mod+grave to STOP and transcribe"
+    # Check how long the recording has been running
+    if [ -f /tmp/a.au ]; then
+        size=$(du -h /tmp/a.au | cut -f1)
+        echo "   Audio file size: $size"
+    fi
+else
+    echo "⚪ Idle - Press \$mod+grave to START recording"
+fi


### PR DESCRIPTION
(This is totally AI-authored, but it worked for me to get things running on X + i3! Feel free to close out the PR if this isn't functionality you're interested in -- but in any case, thanks for a great working example to start from!)

# Add X11/i3 Support via Pluggable Backend Architecture

## Summary

This PR adds support for **X11/i3** window managers while maintaining full backward compatibility with the existing **Sway/Wayland** implementation. No changes required for existing users.

## Motivation

whispy is currently Sway/Wayland-specific. Many Linux users run i3 on X11 and would benefit from this speech-to-text functionality. This PR makes whispy accessible to a broader audience without breaking existing functionality.

## Implementation

### Backend Architecture
Introduced a pluggable backend system using Go build tags:
- **`Backend` interface** defines window manager operations (get window class, type text, paste text)
- **`SwayBackend`** (default, `!x11` build tag) - existing Sway/Wayland functionality
- **`X11Backend`** (`x11` build tag) - new X11/i3 support

### Key Features
- **Zero breaking changes** - default build remains Sway-only
- **Compile-time selection** - backend chosen via build tags
- **Clean abstraction** - window manager specifics isolated in backend files

### Dependencies by Backend

**Sway/Wayland (default):**
- go-sway
- ydotool
- wl-clipboard

**X11/i3 (new):**
- xdotool
- xclip

## Helper Scripts

Included practical scripts for setup and monitoring:

1. **`start-whispy.sh`** - Daemon launcher with proper backgrounding
   - Essential for i3 auto-start
   - Configurable model path and log file
   - Validation checks

2. **`whispy-status.sh`** - Status checker
   - Shows idle/recording state
   - Displays audio file size during recording
   - Useful for debugging

3. **`bumblebee-status/whispy.py`** - i3bar indicator module
   - Visual feedback: ⚪ idle / 🔴REC recording
   - Updates every second
   - Integrates with bumblebee-status

## Documentation

Comprehensive README updates:
- Clear prerequisites by backend
- Build instructions for both backends
- Setup examples for Sway and i3
- Usage guide and troubleshooting
- Status monitoring documentation

## Testing

Both backends compile successfully:
```bash
# Sway/Wayland (default)
go build

# X11/i3
go build -tags=x11
```

Tested on:
- i3 window manager with X11
- PipeWire audio (pw-record)
- whisper.cpp base.en model
- xdotool + xclip for X11 operations

## Example Configurations

### Sway (unchanged)
```
exec whispy ~/.cache/whisper/ggml-base.en.bin
bindsym $mod+grave exec 'pkill -USR2 whispy'
```

### i3 (new)
```
exec --no-startup-id /path/to/whispy/scripts/start-whispy.sh
bindsym $mod+grave exec --no-startup-id pkill -USR2 whispy
```

## Backward Compatibility

✅ **100% backward compatible**
- Default build unchanged (Sway-only)
- No dependency changes for Sway users
- Existing configs work without modification
- go-sway remains the default backend

## Trade-offs

- Adds ~200 lines of code (backend abstraction + X11 implementation)
- Build tags add slight complexity
- Documentation is longer (covers both backends)

However:
- Clean separation of concerns
- No code duplication
- Easy to maintain both backends
- Foundation for future backends (Hyprland, etc.)

## Future Considerations

This architecture makes it trivial to add support for other window managers (Hyprland, etc.) by implementing the `Backend` interface with appropriate build tags.

## Checklist

- [x] Backend abstraction implemented
- [x] Both backends compile successfully
- [x] Backward compatibility maintained
- [x] Helper scripts included
- [x] Comprehensive documentation
- [x] Example configurations provided

## Notes

The i3 implementation uses `xdotool` instead of `ydotool` because:
1. More mature X11 integration
2. Better documented for X11 use cases
3. Direct X11 API access (no daemon required)
4. Widely available in Linux distributions
